### PR TITLE
IN-2229 Require production branch to have a merged PR before sending to rubygems

### DIFF
--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -1,7 +1,8 @@
 name: EditorConfig
 
 on:
-  workflow_call:
+  pull_request:
+    types: [ opened, reopened, synchronize ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,7 +1,8 @@
 name: Rubocop
 
 on:
-  workflow_call:
+  pull_request:
+    types: [ opened, reopened, synchronize ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -2,11 +2,18 @@
 name: RubyGems
 
 on:
-  release:
-    types: [ published ]
+  pull_request:
+    # Only on the production branch
+    branches:
+      - production
+    # Only when closed
+    types:
+      - closed
+  workflow_dispatch:
 
 jobs:
   push:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -1,7 +1,8 @@
 name: Tester
 
 on:
-  workflow_call:
+  pull_request:
+    types: [ opened, reopened, synchronize ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/yard.yml
+++ b/.github/workflows/yard.yml
@@ -1,7 +1,8 @@
 name: Yard
 
 on:
-  workflow_call:
+  pull_request:
+    types: [ opened, reopened, synchronize ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
# Summary

Require production branch to have a merged PR before sending to rubygems.
Fix github action events.

## Checklist

* [ ] Did we think two weeks into the future and not two years? Is this addition malleable to be changed tomorrow without being over-engineered today?
* [ ] Have you updated the changelog with this behavior?
