### PR TITLE
IN-2565 - Rails 7.2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.2.0] - 2025-02-18
+
+### Changed
+
+1. Update ActiveSupport Version to support Rails 7.2.2.1. (IN-2565)
+
+## [4.1.1] - 2024-12-19
 
 ### Added
 
 1. Adds `Entity::Fund` `active?` and `default?` interrogatives
 
-## [4.0.1] - 2024-09-13
+## [4.0.1] - 2024-09-16
 
 This version adds support for Ruby 3.3.5. No real changes were required. We just needed to add some gems to the gemspec
 to silence deprecation warnings.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    faithteams-api (4.1.1)
-      activesupport (>= 7.0.8, <= 7.1.5.1)
+    faithteams-api (4.2.0)
+      activesupport (~> 7.2.2)
       http (~> 5.1)
       logger (~> 1.6.1)
       ostruct (~> 0.6.0)
@@ -11,19 +11,18 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.5.1)
+    activesupport (7.2.2.1)
       base64
       benchmark (>= 0.3)
       bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+      concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
       logger (>= 1.4.2)
       minitest (>= 5.1)
-      mutex_m
       securerandom (>= 0.3)
-      tzinfo (~> 2.0)
+      tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
@@ -84,7 +83,6 @@ GEM
     lumberjack (1.2.10)
     method_source (1.1.0)
     minitest (5.25.4)
-    mutex_m (0.3.0)
     nenv (0.3.0)
     notiffany (0.1.3)
       nenv (~> 0.1)

--- a/faithteams-api.gemspec
+++ b/faithteams-api.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", ">= 7.0.8", "<= 7.1.5.1"
+  spec.add_dependency "activesupport", "~> 7.2.2"
   spec.add_dependency "http", "~> 5.1"
   spec.add_dependency "logger", "~> 1.6.1"
   spec.add_dependency "ostruct", "~> 0.6.0"

--- a/lib/faithteams/version.rb
+++ b/lib/faithteams/version.rb
@@ -2,5 +2,5 @@
 
 module FaithTeams
   # Current version number.
-  VERSION = "4.1.1"
+  VERSION = "4.2.0"
 end


### PR DESCRIPTION
# Summary

1. Update ActiveSupport Version to support Rails 7.2.2.1. (IN-2565)

## Checklist

* [x] Did we think two weeks into the future and not two years? Is this addition malleable to be changed tomorrow without being over-engineered today?
* [x] Have you updated the changelog with this behavior?
