### PR TITLE
Production Release of 4.6.1

### DIFF
--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
       - name: Install editorconfig-checker
         run: npm install --global editorconfig-checker
       - name: Run editorconfig-checker

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -10,7 +10,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -25,12 +25,12 @@ jobs:
 
     steps:
       # Set up
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: ruby
+          ruby-version: 3.3
 
       # Release
       - uses: rubygems/release-gem@v1

--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -10,7 +10,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/yard.yml
+++ b/.github/workflows/yard.yml
@@ -10,7 +10,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.6.1]
+
+### Changed
+
+1. Use GH actions for Node 24. (ISG-92)
+
+### Fixed
+
+1. Lock rubygems.yml ruby version to 3.3. (ISG-92)
+
 ## [4.6.0]
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,4 +186,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-  4.0.9
+   2.5.17

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    faithteams-api (4.6.0)
+    faithteams-api (4.6.1)
       activesupport (~> 7.2)
       http (~> 5.1)
 

--- a/lib/faithteams/version.rb
+++ b/lib/faithteams/version.rb
@@ -2,5 +2,5 @@
 
 module FaithTeams
   # Current version number.
-  VERSION = "4.6.0"
+  VERSION = "4.6.1"
 end


### PR DESCRIPTION
# Summary

## [4.6.1]

### Changed

1. Use GH actions for Node 24. (ISG-92)

### Fixed

1. Lock rubygems.yml ruby version to 3.3. (ISG-92)

## Checklist

* [x] Did we think two weeks into the future and not two years? Is this addition malleable to be changed tomorrow without being over-engineered today?
* [x] Have you updated the changelog with this behavior?
