### PR TITLE
Add agent context: AGENTS.md + CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md — faithteams-api
+
+## What this is
+Ruby client gem for the **FaithTeams** API — used by Tithely's ChMS integration repos to talk to FaithTeams.
+
+## Develop
+- Standard Bundler gem workflow: `bundle install`.
+- Run tests with `bundle exec rspec` and lint with the repo's Rubocop (confirm exact tasks from the Rakefile / README / .github workflows).
+- Bump the gem version + update the changelog when releasing; consumers pin versions.
+
+## Conventions
+- Shared client library — keep the public API backwards-compatible; breaking changes need a
+  major version bump + a migration note in the PR.
+- Match the existing module/class structure and error-handling patterns.
+- Cover new API resources/methods with specs; stub HTTP — no live API calls in tests.
+
+## Don't
+- Don't commit API keys or credentials; tests must not hit the live FaithTeams API.
+- Don't break the public interface without a version bump.
+
+## Branching & PRs
+Cut feature branches from `master`; open PRs back to `master`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,14 +5,13 @@ Ruby client gem for the **FaithTeams** API — used by Tithely's ChMS integratio
 
 ## Develop
 - Standard Bundler gem workflow: `bundle install`.
-- Run tests with `bundle exec rspec` and lint with the repo's Rubocop (confirm exact tasks from the Rakefile / README / .github workflows).
-- Bump the gem version + update the changelog when releasing; consumers pin versions.
+- Run tests with `bundle exec rspec`; lint with the repo's Rubocop (confirm exact tasks from the Rakefile / README / .github workflows).
+- Bump the gem version and update the changelog when releasing; consumers pin versions.
 
 ## Conventions
-- Shared client library — keep the public API backwards-compatible; breaking changes need a
-  major version bump + a migration note in the PR.
+- Shared client library: keep the public API backwards-compatible; breaking changes need a major version bump plus a migration note in the PR.
 - Match the existing module/class structure and error-handling patterns.
-- Cover new API resources/methods with specs; stub HTTP — no live API calls in tests.
+- Cover new API resources/methods with specs; stub HTTP so tests make no live API calls.
 
 ## Don't
 - Don't commit API keys or credentials; tests must not hit the live FaithTeams API.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+# Claude Code Instructions
+
+Read AGENTS.md and follow it as if it were written here.
+Do not duplicate or override its rules.


### PR DESCRIPTION
Adds agent-context files as part of the AI Agentic SDLC Phase 1 rollout (CLAUDE.md coverage).

- AGENTS.md — repo-specific agent guidance.
- CLAUDE.md — thin pointer to AGENTS.md.

AGENTS.md is a first pass — please review before merging.